### PR TITLE
Fix broken script paths in people, projects, and publications pages

### DIFF
--- a/people/people.html
+++ b/people/people.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>IIIT-B SELab Page</title>
-    <script src="./ js/bootstrap.js"></script>
+    <script src="../js/bootstrap.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/handlebars-v3.0.3.js"></script>
     <script src="../js/pub.js"></script>

--- a/projects/projects.html
+++ b/projects/projects.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IIIT-B SELab Page</title>
-    <script src="./ js/bootstrap.js"> </script>
+    <script src="../js/bootstrap.js"> </script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/handlebars-v3.0.3.js"> </script>
     <script src="../js/pro.js"></script>

--- a/publications/publications.html
+++ b/publications/publications.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IIIT-B SELab Page</title>
-    <script src="./ js/bootstrap.js"> </script>
+    <script src="../js/bootstrap.js"> </script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/handlebars-v3.0.3.js"> </script>
     <script src="../js/pub.js"></script>


### PR DESCRIPTION
- Corrected script src from `./ js/bootstrap.js` to `../js/bootstrap.js`
- Fixed syntax error caused by space in path
- Affects people.html, projects.html, and publications.html