### PR TITLE
Remove duplicate jQuery loading

### DIFF
--- a/news/news.html
+++ b/news/news.html
@@ -4,7 +4,7 @@
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
 
     <meta charset="utf-8">
@@ -16,7 +16,6 @@
     <script src="../js/handlebars-v3.0.3.js"></script>
     <script src="../js/pub.js"></script>
     <script src="../js/nav.js"></script>
-    <script src="../js/jquery.min.js"></script>
     <script src="../js/gallery.js"></script>
     <link href="../css/bootstrap.css" rel="stylesheet">
     <link href="../css/gallery.css" rel="stylesheet">

--- a/projects/projects.html
+++ b/projects/projects.html
@@ -5,17 +5,16 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IIIT-B SELab Page</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <script src="../js/bootstrap.js"> </script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/handlebars-v3.0.3.js"> </script>
     <script src="../js/pro.js"></script>
     <script src="../js/nav.js"></script>
-    <script src="../js/jquery.min.js"></script>
     <script src="../js/gallery.js"> </script>
     <link href="../css/bootstrap.css" rel="stylesheet">
     <link href="../css/gallery.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="../css/selab.css">   
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="../css/selab.css">
   </head>
 	<body>
 


### PR DESCRIPTION
- Removed local jquery.min.js references from projects.html and news.html
- Standardized to jQuery 3.6.0 CDN for better caching
- Added integrity and crossorigin attributes for security (SRI)
- Moved jQuery to load before other scripts that depend on it

This resolves the duplicate jQuery loading issue identified in the quality improvement plan.